### PR TITLE
Add compatibility with gitlab (and maybe others)

### DIFF
--- a/lib/device_grid/plugin.rb
+++ b/lib/device_grid/plugin.rb
@@ -23,7 +23,7 @@ module Danger
       # To use the local fastlane instead of bundle
       prefix_command = "./bin/" if FastlaneCore::Helper.test?
 
-      deep_link_matches = github.pr_body.match(/:link:\s(.*)/) # :link: emoji
+      deep_link_matches = gitlab.pr_body.match(/:link:\s(.*)/) # :link: emoji
       deep_link = deep_link_matches[1] if deep_link_matches
 
       html = ""

--- a/lib/device_grid/plugin.rb
+++ b/lib/device_grid/plugin.rb
@@ -23,7 +23,7 @@ module Danger
       # To use the local fastlane instead of bundle
       prefix_command = "./bin/" if FastlaneCore::Helper.test?
 
-      deep_link_matches = gitlab.pr_body.match(/:link:\s(.*)/) # :link: emoji
+      deep_link_matches = git.pr_body.match(/:link:\s(.*)/) # :link: emoji
       deep_link = deep_link_matches[1] if deep_link_matches
 
       html = ""


### PR DESCRIPTION
With this modification device_grid works with gitlab, before it crashes with message: undefined method `github'